### PR TITLE
Clarified default_stage, made example 'staging'

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -140,13 +140,13 @@ set('ssh_multiplexing', true);
 
 ### default\_stage
 
-If the hosts declaration has stages, this option allows you to select the default stage to deploy with `dep deploy`.
+This option allows you to select the default stage to deploy with `dep deploy`. Note that your Deployer script must have at least one stage and you must specify a stage, even if you are just running [local-only tasks](https://deployer.org/docs/tasks.html#local-tasks). Therefore it is recommended you use this command to always set a default stage.
 
 ~~~php
-set('default_stage', 'prod');
+set('default_stage', 'staging');
 
 host(...)
-    ->stage('prod');
+    ->stage('staging');
 ~~~
 
 You can also set callable as an argument if you need some more complex ways to determine default stage.


### PR DESCRIPTION
Addresses issue #1866

Clarified that you need to set a default_stage in your Deployer script, and also changed the example to 'staging' since that is a better example default to have (instead of production).

| Q             | A
| ------------- | ---
| Bug fix?      |  No
| New feature?  | No
| BC breaks?    |  No
| Deprecations? |  No
| Fixed tickets | 1866

> Do not forget to add notes about your changes to CHANGELOG.md
>
> Easiest way to do it, by running next command:
>
>     php bin/changelog
>
